### PR TITLE
Update link to presentation slides in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ✨ Vibe Coding Workshop
 
-> **📊 Slides included!** The presentation deck is available in this repo — see [`Vibe Coding with GitHub Copilot.pdf`](Vibe%20Coding%20with%20GitHub%20Copilot.pdf).
+> **📊 Slides included!** The presentation deck is available in this repo — see [`Vibe Coding with GitHub Copilot.pdf`](slides.pdf).
 
 <img src="docs/images/vibe-workflow.png" alt="The Vibe Coding Workflow" width="800">
 


### PR DESCRIPTION
This pull request updates the link to the presentation deck in the `README.md` file to point to a simplified file name.

Documentation update:

* Changed the slide deck link in `README.md` from `Vibe Coding with GitHub Copilot.pdf` to `slides.pdf` for easier access and consistency.