### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing to Vibe Task Tracker
+
+Thanks for your interest in contributing! This is a hands-on workshop project
+that demonstrates GitHub Copilot's vibe coding workflow — see the
+[README](README.md) for the full overview, tech stack, and learning goals.
+
+## Prerequisites
+
+See the [Prerequisites](README.md#-prerequisites) section in the README. The
+quickest path is to open the repo in the included dev container or a GitHub
+Codespace — Java 21, Maven, and the GitHub CLI come pre-configured.
+
+## Workflow
+
+```bash
+# 1. Fork the repo on GitHub, then clone your fork
+git clone https://github.com/<your-username>/vibecoding.git
+cd vibecoding
+
+# 2. Create a focused feature branch
+git checkout -b my-change
+
+# 3. Make your changes and commit
+git commit -am "Describe your change"
+
+# 4. Push and open a pull request against main
+git push origin my-change
+```
+
+## Build & Test
+
+```bash
+./mvnw test              # run the test suite
+./mvnw spring-boot:run   # run the app on http://localhost:3000
+```
+
+On Windows, use `mvnw.cmd` instead of `./mvnw`.
+
+## Pull Request Guidelines
+
+- Keep PRs small and focused on a single change.
+- Include a clear description of **what** changed and **why**.
+- Make sure `./mvnw test` passes before requesting review.
+- Follow the conventions in
+  [`.github/copilot-instructions.md`](.github/copilot-instructions.md)
+  (constructor injection, proper HTTP status codes, small focused methods, etc.).
+
+## License & Conduct
+
+This project is released under the [MIT License](README.md#-license). Please be
+kind and respectful in issues, PRs, and discussions.

--- a/README.md
+++ b/README.md
@@ -195,6 +195,11 @@ The full prompt is also available in [RECREATE-PROMPT.md](RECREATE-PROMPT.md).
 
 Want to go beyond the editor and vibe code programmatically? The **[GitHub Copilot SDK for Java](https://github.com/roryp/github-copilot-sdk)** gives you programmatic access to GitHub Copilot via the GitHub Copilot CLI, so you can build AI-powered tools, assistants, and agentic workflows — entirely in Java.
 
+## 🤝 Contributing
+
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for the
+workflow, build/test commands, and pull request guidelines.
+
 ## 📜 License
 
 MIT


### PR DESCRIPTION
The repo had no contribution guide, so new contributors had to infer the workflow from the README. This adds a short, scannable `CONTRIBUTING.md` so the path to a first PR is obvious.

The guide stays minimal on purpose: it points back to the README for setup and tech stack rather than duplicating them, then covers just the essentials: fork/branch/PR workflow with the relevant git commands, `./mvnw test` and `./mvnw spring-boot:run`, basic PR guidelines (focused PRs, clear description, tests pass, follow `.github/copilot-instructions.md` conventions), and a one-line license/conduct note.

`README.md` gets a small "Contributing" section above the License so the new file is discoverable from the project's front page.

Docs-only change, no build or test impact.

Fixes: #8